### PR TITLE
SalsifyID field is now editable

### DIFF
--- a/src/ORM/SalsifyFetchExtension.php
+++ b/src/ORM/SalsifyFetchExtension.php
@@ -123,7 +123,7 @@ class SalsifyFetchExtension extends LeftAndMainExtension
         }
 
         if (!$record || !$record->SalsifyID) {
-            $this->owner->httpError(404, "Bad salsify ID: " . (int)$id);
+            $this->owner->httpError(404, "Bad salsify ID: $id");
         }
 
         ImportTask::config()->remove('output');
@@ -166,6 +166,11 @@ class SalsifyFetchExtension extends LeftAndMainExtension
         ]);
 
         $response = $client->get($url);
+
+        if ($response->getStatusCode() == 404) {
+            $this->owner->httpError(404, "Bad salsify ID: $salsifyID");
+        }
+
         return json_decode($response->getBody(), true);
     }
 

--- a/src/ORM/SalsifyIDExtension.php
+++ b/src/ORM/SalsifyIDExtension.php
@@ -3,6 +3,7 @@
 namespace Dyanmic\Salsify\ORM;
 
 use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\CMS\Forms\SiteTreeURLSegmentField;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Forms\DatetimeField;
@@ -46,7 +47,7 @@ class SalsifyIDExtension extends DataExtension
         }
 
         if ($this->owner->SalsifyID) {
-            $salsifyID->setReadonly(true);
+            $salsifyID->setTemplate(SiteTreeURLSegmentField::class)->addExtraClass('urlsegment');
         }
         $salsifyUpdatedAt->setReadonly(true);
     }
@@ -92,5 +93,15 @@ class SalsifyIDExtension extends DataExtension
 
             $actions->push($action);
         }
+    }
+
+    /**
+     *
+     */
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        $this->owner->SalsifyID = trim($this->owner->SalsifyID);
     }
 }

--- a/templates/SilverStripe/CMS/Forms/SiteTreeURLSegmentField.ss
+++ b/templates/SilverStripe/CMS/Forms/SiteTreeURLSegmentField.ss
@@ -1,0 +1,37 @@
+<div class="preview-holder input-group">
+    <% if $URL %>
+    <a class="URL-link" href="$URL" target="_blank">
+        $URL
+    </a>
+    <% else %>
+        <input $AttributesHTML readonly>
+    <% end_if %>
+    <% if not $IsReadonly %>
+        <% if not $URL %>
+        <div class="input-group-append">
+        <% end_if %>
+        <button role="button" type="button" class="btn btn-outline-secondary btn-sm edit">
+            <%t SilverStripe\CMS\Forms\SiteTreeURLSegmentField.Edit 'Edit' %>
+        </button>
+        <% if not $URL %>
+        </div>
+        <% end_if %>
+    <% end_if %>
+</div>
+
+<div class="edit-holder">
+    <div class="input-group">
+        <input $AttributesHTML />
+        <div class="input-group-append">
+            <button role="button" data-icon="accept" type="button" class="btn btn-primary update">
+                <%t SilverStripe\CMS\Forms\SiteTreeURLSegmentField.OK 'OK' %>
+            </button>
+        </div>
+        <div class="input-group-append">
+            <button role="button" data-icon="cancel" type="button" class="btn btn-outline-secondary btn-sm input-group-append cancel">
+                <%t SilverStripe\CMS\Forms\SiteTreeURLSegmentField.Cancel 'Cancel' %>
+            </button>
+        </div>
+    </div>
+    <% if $HelpText %><p class="form__field-description">$HelpText</p><% end_if %>
+</div>

--- a/tests/ORM/SalsifyIDExtensionTest.php
+++ b/tests/ORM/SalsifyIDExtensionTest.php
@@ -5,6 +5,7 @@ namespace Dynamic\Salsify\Tests\Model\ORM;
 use Dyanmic\Salsify\ORM\SalsifyIDExtension;
 use Dynamic\Salsify\Tests\TestOnly\MappedObject;
 use Dynamic\Salsify\Tests\TestOnly\TestController;
+use SilverStripe\CMS\Forms\SiteTreeURLSegmentField;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Dev\SapphireTest;
@@ -52,7 +53,7 @@ class SalsifyIDExtensionTest extends SapphireTest
         $fields = $object->getCMSFields();
         $this->assertInstanceOf(FieldList::class, $fields);
         $this->assertInstanceOf(FormField::class, $fields->fieldByName('SalsifyID'));
-        $this->assertTrue($fields->fieldByName('SalsifyID')->isReadonly());
+        $this->assertEquals(SiteTreeURLSegmentField::class, $fields->fieldByName('SalsifyID')->getTemplate());
     }
 
     /**
@@ -65,7 +66,7 @@ class SalsifyIDExtensionTest extends SapphireTest
         $fields = $object->getCMSFields();
         $this->assertInstanceOf(FieldList::class, $fields);
         $this->assertInstanceOf(FormField::class, $fields->fieldByName('SalsifyID'));
-        $this->assertFalse($fields->fieldByName('SalsifyID')->isReadonly());
+        $this->assertNotEquals(SiteTreeURLSegmentField::class, $fields->fieldByName('SalsifyID'));
     }
 
     /**


### PR DESCRIPTION
  - uses same system as the SiteTreeURLSegmentField field
SalsifyID is now trimmed before write
  - prevents extra spaces effecting salsify pull