### PR TITLE
Fixed salsify relations type causing empty objects to be written

### DIFF
--- a/src/Model/Mapper.php
+++ b/src/Model/Mapper.php
@@ -559,16 +559,21 @@ class Mapper extends Service
             return;
         }
 
-        // write the object so relations can be written
-        if (!$object->exists()) {
-            $object->write();
-        }
-
         // change to an array and filter out empty values
         if (!is_array($value)) {
             $value = [$value];
         }
         $value = array_filter($value);
+
+        // don't try to write an empty set
+        if (!count($value)) {
+            return;
+        }
+
+        // write the object so relations can be written
+        if (!$object->exists()) {
+            $object->write();
+        }
 
         $this->removeUnrelated($object, $dbField, $value);
         $this->writeManyRelation($object, $dbField, $value, $sortColumn);


### PR DESCRIPTION
  - writeValue() now only handles many relations if the value isn't an empty array