### PR TITLE
Field type config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ See [License](license.md)
     - [Mapper](#mapper)
       - [Unique Fields](#unique-fields)
       - [Field Types](#field-types)
+        - [Raw](#raw)
+        - [SalsifyID, SalsifyUpdatedAt, and SalsifyRelationsUpdatedAt](#salsifyid-salsifyupdatedat-and-salsifyrelationsupdatedat)
         - [Literal](#literal)
         - [Files and Images](#files-and-images)
           - [Image Resizing](#image-resizing)
@@ -190,8 +192,37 @@ The unique fields will be added to an array, with the values for each product an
 This allows for multiple compound unique fields.
 
 #### Field Types
-Field types can be `Raw`, `Literal`, `File`, `Image`, `HasOne`, `HasMany`.
-By default the `Raw` type is used. More types can also be added.
+The built in field types are `Raw`, `Literal`, `File`, `Image`, `HasOne`, `HasMany`.
+There are some specialized field types that are `SalsifyID`, `SalsifyUpdatedAt`, `SalsifyRelationsUpdatedAt` that are meant for mapping to specific fields without modifications.
+More types can also be added.
+
+##### Raw
+By default the `Raw` type is used. It will write the salsify property value into the object field.
+```yaml
+Dynamic\Salsify\Model\Mapper.example:
+  example:
+    mapping:
+      \Page:
+        Title: 'Web Title'
+```
+
+#### SalsifyID, SalsifyUpdatedAt, and SalsifyRelationsUpdatedAt
+Fields that have these types cannot be modified, but will be handled like a raw type.
+```yaml
+Dynamic\Salsify\Model\Mapper.example:
+  example:
+    mapping:
+      \Page:
+        SalsifyID:
+          salsifyField: 'salsify:id'
+          type: SalsifyID
+        SalsifyUpdatedAt:
+          salsifyField: 'salsify:updated_at'
+          type: SalsifyUpdatedAt
+        SalsifyRelationsUpdatedAt:
+          salsifyField: 'salsify:relations_updated_at'
+          type: SalsifyRelationsUpdatedAt
+```
 
 ##### Literal
 To set a field that doesn't have a salsify field a literal field can be used.

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,10 +6,6 @@ Dynamic\Salsify\Model\Fetcher:
 
 Dynamic\Salsify\Model\Mapper:
   skipUpToDate: true
-  typeFallbacks:
-    SalsifyRelationTimeStamp: Raw
-  field_types:
-    - 'SalsifyRelationTimeStamp'
   extensions:
     - Dynamic\Salsify\TypeHandler\RawHandler
     - Dynamic\Salsify\TypeHandler\LiteralHandler

--- a/docs/en/custom-types.md
+++ b/docs/en/custom-types.md
@@ -1,5 +1,5 @@
 ## Custom Field Types
-Custom field types can be used in mappers. 
+Custom field types can be used in mappers.
 It is recommended to apply field type extensions to the base `Dynamic\Salsify\Model\Mapper` config.
 ```yaml
 Dynamic\Salsify\Model\Mapper:
@@ -8,8 +8,15 @@ Dynamic\Salsify\Model\Mapper:
 ```
 
 All custom field types must be added to the `field_types` configuration.
+Every new type must have an array for a config.
+Possible configuration keys are `requiresWrite`, `requiresSalsifyObjects`, `allowsModification`, and `fallback`.
+ - `requiresWrite` will force the object to write before saving to a field if true. Defualts to `false`.
+ - `requiresSalsifyObjects` will write to a field during the second mapping loop if true. This is useful for salsify relations, or other types that would require all mapped objects to be written. Defualts to `false`.
+ - `allowsModification` will skip any field modifications if false. Defaults to `true`.
+ - `fallback` will allow a field type to fallback to another field type if a handler is not found. The original type's config will be used instead of the fallback's. Good for types that require a slightly different config, but don't need different processing from an existing type.
+
 To handle a field type a method must be used that is named in a specific pattern.
-The pattern is `handle{TYPE_HERE}Type` where `{TYPE_HERE}` is replaced with the value added to the `field_types`.
+The pattern is `handle{TYPE_HERE}Type` where `{TYPE_HERE}` is replaced with the key added to the `field_types`.
 So a handler method for `Image` would be `hadleImageType`.
 The method is passed the object data, data field to map to, configuration for the field, the database field name, and the class the field is applied to.
 
@@ -28,7 +35,18 @@ class CustomHandler extends Extension
      * @var array
      */
     private static $field_types = [
-        'Custom'
+        'Custom' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => true,
+        ],
+        // this would fallback to Custom, but would not run field modifications
+        'CustomNoModification' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => false,
+            'fallback' => 'Custom',
+        ],
     ];
 
     /**

--- a/src/Model/Mapper.php
+++ b/src/Model/Mapper.php
@@ -541,7 +541,11 @@ class Mapper extends Service
         $fieldTypes = $this->config()->get('field_types');
         $types = [];
         foreach ($this->yieldKeyVal($this->config()->get('field_types')) as $field => $config) {
-            if ($config['requiresSalsifyObjects']) {
+            $type = [
+                'type' => $field,
+                'config' => $config,
+            ];
+            if ($this->typeRequiresSalsifyObjects($type)) {
                 $types[] = $field;
             }
         }

--- a/src/Model/Mapper.php
+++ b/src/Model/Mapper.php
@@ -147,8 +147,7 @@ class Mapper extends Service
         $object = null,
         $salsifyRelations = false,
         $forceUpdate = false
-    )
-    {
+    ) {
         if ($salsifyRelations) {
             if (!$this->classConfigHasSalsifyRelation($mappings)) {
                 return null;
@@ -257,7 +256,6 @@ class Mapper extends Service
                 ImportTask::output("Skipping $firstUniqueKey $firstUniqueValue. It is up to Date.");
                 return true;
             }
-
         } else {
             if ($this->objectRelationsUpToDate($object, $data, $firstUniqueKey, $firstUniqueValue)) {
                 ImportTask::output("Skipping $firstUniqueKey $firstUniqueValue relations. It is up to Date.");
@@ -673,7 +671,6 @@ class Mapper extends Service
         $fieldTypes = $this->config()->get('field_types');
         if (is_array($field) && array_key_exists('type', $field)) {
             if (array_key_exists($field['type'], $fieldTypes)) {
-
                 return [
                     'type' => $field['type'],
                     'config' => $fieldTypes[$field['type']],
@@ -705,7 +702,7 @@ class Mapper extends Service
             return $this->{"handle{$typeName}Type"}($class, $salsifyData, $salsifyField, $dbFieldConfig, $dbField);
         }
 
-        if (array_key_exists( 'fallback', $typeConfig)) {
+        if (array_key_exists('fallback', $typeConfig)) {
             $fallback = $typeConfig['fallback'];
             if ($this->hasMethod("handle{$fallback}Type")) {
                 return $this->{"handle{$fallback}Type"}($class, $salsifyData, $salsifyField, $dbFieldConfig, $dbField);

--- a/src/Model/Mapper.php
+++ b/src/Model/Mapper.php
@@ -384,8 +384,8 @@ class Mapper extends Service
         foreach ($this->yieldKeyVal($uniqueFields) as $dbField => $salsifyField) {
             $modifiedData = $data;
             $fieldMapping = $mappings[$dbField];
-
-            $modifiedData = $this->handleModification($class, $dbField, $fieldMapping, $modifiedData);
+            $fieldType = $this->getFieldType($salsifyField);
+            $modifiedData = $this->handleModification($fieldType, $class, $dbField, $fieldMapping, $modifiedData);
 
             // adds unique fields to filter
             if (array_key_exists($salsifyField, $modifiedData)) {
@@ -431,12 +431,8 @@ class Mapper extends Service
             return false;
         }
 
-        $modifiedData = $data;
-        if (array_key_exists('salsify:id', $mappings)) {
-            $modifiedData = $this->handleModification($class, 'salsify:id', $mappings['salsify:id'], $modifiedData);
-        }
         $obj = DataObject::get($class)->filter([
-            'SalsifyID' => $modifiedData['salsify:id'],
+            'SalsifyID' => $data['salsify:id'],
         ])->first();
         if ($obj) {
             return $obj;
@@ -676,7 +672,8 @@ class Mapper extends Service
     {
         $fieldTypes = $this->config()->get('field_types');
         if (is_array($field) && array_key_exists('type', $field)) {
-            if (in_array($field['type'], $fieldTypes)) {
+            if (array_key_exists($field['type'], $fieldTypes)) {
+
                 return [
                     'type' => $field['type'],
                     'config' => $fieldTypes[$field['type']],

--- a/src/TypeHandler/Asset/FileHandler.php
+++ b/src/TypeHandler/Asset/FileHandler.php
@@ -17,8 +17,16 @@ class FileHandler extends AssetHandler
      * @var array
      */
     private static $field_types = [
-        'File',
-        'ManyFiles',
+        'File' => [
+            'requiresWrite' => true,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => true,
+        ],
+        'ManyFiles' => [
+            'requiresWrite' => true,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => true,
+        ],
     ];
 
     /**

--- a/src/TypeHandler/Asset/ImageHandler.php
+++ b/src/TypeHandler/Asset/ImageHandler.php
@@ -19,8 +19,16 @@ class ImageHandler extends AssetHandler
      * @var array
      */
     private static $field_types = [
-        'Image',
-        'ManyImages',
+        'Image' => [
+            'requiresWrite' => true,
+            'requiresSalsifyObject' => false,
+            'allowsModification' => true,
+        ],
+        'ManyImages' => [
+            'requiresWrite' => true,
+            'requiresSalsifyObject' => false,
+            'allowsModification' => true,
+        ],
     ];
 
     /**

--- a/src/TypeHandler/Asset/ImageHandler.php
+++ b/src/TypeHandler/Asset/ImageHandler.php
@@ -21,12 +21,12 @@ class ImageHandler extends AssetHandler
     private static $field_types = [
         'Image' => [
             'requiresWrite' => true,
-            'requiresSalsifyObject' => false,
+            'requiresSalsifyObjects' => false,
             'allowsModification' => true,
         ],
         'ManyImages' => [
             'requiresWrite' => true,
-            'requiresSalsifyObject' => false,
+            'requiresSalsifyObjects' => false,
             'allowsModification' => true,
         ],
     ];

--- a/src/TypeHandler/LiteralHandler.php
+++ b/src/TypeHandler/LiteralHandler.php
@@ -16,7 +16,11 @@ class LiteralHandler extends Extension
      * @var array
      */
     private static $field_types = [
-        'Literal',
+        'Literal' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => true,
+        ],
     ];
 
     /**

--- a/src/TypeHandler/RawHandler.php
+++ b/src/TypeHandler/RawHandler.php
@@ -21,6 +21,12 @@ class RawHandler extends Extension
             'requiresSalsifyObjects' => false,
             'allowsModification' => true,
         ],
+        'SalsifyID' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => false,
+            'fallback' => 'Raw',
+        ],
         'SalsifyUpdatedAt' => [
             'requiresWrite' => false,
             'requiresSalsifyObjects' => false,

--- a/src/TypeHandler/RawHandler.php
+++ b/src/TypeHandler/RawHandler.php
@@ -16,7 +16,17 @@ class RawHandler extends Extension
      * @var array
      */
     private static $field_types = [
-        'Raw'
+        'Raw' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => true,
+        ],
+        'SalsifyUpdatedAt' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => false,
+            'fallback' => 'Raw',
+        ],
     ];
 
     /**

--- a/src/TypeHandler/Relation/HasOneHandler.php
+++ b/src/TypeHandler/Relation/HasOneHandler.php
@@ -16,7 +16,11 @@ class HasOneHandler extends Extension
      * @var array
      */
     private static $field_types = [
-        'HasOne',
+        'HasOne' => [
+            'requiresWrite' => true,
+            'requiresSalsifyObject' => false,
+            'allowsModification' => true,
+        ],
     ];
 
     /**

--- a/src/TypeHandler/Relation/HasOneHandler.php
+++ b/src/TypeHandler/Relation/HasOneHandler.php
@@ -18,7 +18,7 @@ class HasOneHandler extends Extension
     private static $field_types = [
         'HasOne' => [
             'requiresWrite' => true,
-            'requiresSalsifyObject' => false,
+            'requiresSalsifyObjects' => false,
             'allowsModification' => true,
         ],
     ];

--- a/src/TypeHandler/Relation/ManyHandler.php
+++ b/src/TypeHandler/Relation/ManyHandler.php
@@ -18,7 +18,11 @@ class ManyHandler extends Extension
      * @var array
      */
     private static $field_types = [
-        'ManyRelation'
+        'ManyRelation' => [
+            'requiresWrite' => true,
+            'requiresSalsifyObjects' => false,
+            'allowsModification' => true,
+        ],
     ];
 
     /**

--- a/src/TypeHandler/Relation/SalsifyRelationHandler.php
+++ b/src/TypeHandler/Relation/SalsifyRelationHandler.php
@@ -15,7 +15,17 @@ class SalsifyRelationHandler extends Extension
      * @var array
      */
     private static $field_types = [
-        'SalsifyRelation'
+        'SalsifyRelation' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => true,
+            'allowsModification' => false,
+        ],
+        'SalsifyRelationsUpdatedAt' => [
+            'requiresWrite' => false,
+            'requiresSalsifyObjects' => true,
+            'allowsModification' => false,
+            'fallback' => 'Raw',
+        ],
     ];
 
     /**

--- a/tests/data.json
+++ b/tests/data.json
@@ -56,7 +56,7 @@
       },
       {
         "salsify:id": "DA-002-003",
-        "salsify:url": "http://www.4usky.com/data/out/14/164101780-brooklyn-bridge-wallpapers.jpg",
+        "salsify:url": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/Brooklyn_Bridge_Manhattan.jpg/330px-Brooklyn_Bridge_Manhattan.jpg",
         "salsify:name": "brooklyn-bridge-lights.jpg",
         "salsify:created_at": "2018-11-12T17:19:29.454Z",
         "salsify:updated_at": "2018-11-12T17:20:10.847Z",


### PR DESCRIPTION
Added field type configuration options
  - removes hard coding for salsify relation fields
  - added field types that cannot be modified (SalsifyID and timestamps for updates)

Resolves #58 